### PR TITLE
DNSv2. Added more information in error

### DIFF
--- a/pkg/v2/error.go
+++ b/pkg/v2/error.go
@@ -22,10 +22,10 @@ type (
 func (e BadResponseError) Error() string {
 	err := fmt.Sprintf("error response: %v.", e.ErrorMsg)
 	if e.Description != "" {
-		err += fmt.Sprintf(" description: %v.", e.Description)
+		err += fmt.Sprintf(" Description: %v.", e.Description)
 	}
 	if e.Location != "" {
-		err += fmt.Sprintf(" location: %v.", e.Location)
+		err += fmt.Sprintf(" Location: %v.", e.Location)
 	}
 
 	return err

--- a/pkg/v2/error.go
+++ b/pkg/v2/error.go
@@ -12,11 +12,21 @@ var (
 
 type (
 	BadResponseError struct {
-		ErrorMsg string `json:"error,omitempty"` //nolint: tagliatelle
-		Code     int    `json:"code"`
+		ErrorMsg    string `json:"error,omitempty"` //nolint: tagliatelle
+		Description string `json:"description,omitempty"`
+		Location    string `json:"location,omitempty"`
+		Code        int    `json:"code"`
 	}
 )
 
 func (e BadResponseError) Error() string {
-	return fmt.Sprintf("error response: %v", e.ErrorMsg)
+	err := fmt.Sprintf("error response: %v.", e.ErrorMsg)
+	if e.Description != "" {
+		err += fmt.Sprintf(" description: %v.", e.Description)
+	}
+	if e.Location != "" {
+		err += fmt.Sprintf(" location: %v.", e.Location)
+	}
+
+	return err
 }

--- a/pkg/v2/testing/test_utils.go
+++ b/pkg/v2/testing/test_utils.go
@@ -102,3 +102,22 @@ func mockListRRSetResponse(count int) string {
 func mockCreateRRSetResponse() string {
 	return mockGetRRSetResponse()
 }
+
+func mockCreateZoneConflictResponse() string {
+	return `
+	{
+		"error": "bad_request",
+		"description": "Conflict"
+	  }
+	`
+}
+
+func mockCreateZoneFieldRequiredResponse() string {
+	return `
+	{
+		"error": "bad_request",
+		"description": "field required",
+		"location": "body.name"
+	}
+	`
+}

--- a/pkg/v2/testing/zoneManager_test.go
+++ b/pkg/v2/testing/zoneManager_test.go
@@ -30,8 +30,6 @@ func (s *ZoneManageSuite) TearDownTest() {
 }
 
 func (s *ZoneManageSuite) TestCreateZone_ok() {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder(
 		http.MethodPost,
 		fmt.Sprintf("%s%s", testAPIURL, rootPath),
@@ -53,8 +51,6 @@ func (s *ZoneManageSuite) TestCreateZone_ok() {
 }
 
 func (s *ZoneManageSuite) TestGetZone_ok() {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 	path := fmt.Sprintf(zonePath, testUUID)
 	httpmock.RegisterResponder(
 		http.MethodGet,
@@ -104,8 +100,6 @@ func (s *ZoneManageSuite) TestDeleteZone_ok() {
 }
 
 func (s *ZoneManageSuite) TestCreateZone_err_conflict() {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder(
 		http.MethodPost,
 		fmt.Sprintf("%s%s", testAPIURL, rootPath),
@@ -119,13 +113,11 @@ func (s *ZoneManageSuite) TestCreateZone_err_conflict() {
 	zone, err := testClient.CreateZone(testCtx, newZone)
 
 	s.Empty(zone)
-	expectedError := "error response: bad_request. description: Conflict."
+	expectedError := "error response: bad_request. Description: Conflict."
 	s.EqualValues(err.Error(), expectedError)
 }
 
 func (s *ZoneManageSuite) TestCreateZone_err_bad_request_with_description_and_location() {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder(
 		http.MethodPost,
 		fmt.Sprintf("%s%s", testAPIURL, rootPath),
@@ -139,6 +131,6 @@ func (s *ZoneManageSuite) TestCreateZone_err_bad_request_with_description_and_lo
 	zone, err := testClient.CreateZone(testCtx, newZone)
 
 	s.Empty(zone)
-	expectedError := "error response: bad_request. description: field required. location: body.name."
+	expectedError := "error response: bad_request. Description: field required. Location: body.name."
 	s.EqualValues(err.Error(), expectedError)
 }


### PR DESCRIPTION
Добавил отображение подробной информации об ошибке, которая возвращается с апи. Добавил тесты.
сделал через BadResponseError, так как структура использовалась в коде.
Была ещё структура APIError. Может надо было сделать парсинг ошибки в неё, а потом её конвертировать в BadResponseError? 